### PR TITLE
Try noop-buildpack in manifest.yml

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -12,3 +12,6 @@ applications:
   memory: 128M
   no-route: true
   name: dsx-twitter-auto-analysis
+  health-check-type: none
+  buildpack: noop-buildpack
+


### PR DESCRIPTION
This notebook doesn't run in Bluemix. It runs in DSX.
Try noop-build pack to avoid error at end and use
health-check-type none