### PR TITLE
move wordcloud import

### DIFF
--- a/notebooks/dsx_twitter_auto_analysis.ipynb
+++ b/notebooks/dsx_twitter_auto_analysis.ipynb
@@ -43,7 +43,6 @@
     "import matplotlib\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from wordcloud import WordCloud, STOPWORDS\n",
     "\n",
     "# Display Matplotlib output in the notebook\n",
     "%matplotlib inline"
@@ -88,7 +87,8 @@
     "# the kernel and if you restart the kernel, then you should start\n",
     "# at the top of the notebook again.\n",
     "\n",
-    "!pip install wordcloud"
+    "!pip install wordcloud\n",
+    "from wordcloud import WordCloud, STOPWORDS\n"
    ]
   },
   {

--- a/notebooks/dsx_twitter_auto_analysis.ipynb
+++ b/notebooks/dsx_twitter_auto_analysis.ipynb
@@ -87,8 +87,7 @@
     "# the kernel and if you restart the kernel, then you should start\n",
     "# at the top of the notebook again.\n",
     "\n",
-    "!pip install wordcloud\n",
-    "from wordcloud import WordCloud, STOPWORDS\n"
+    "!pip install wordcloud\n"
    ]
   },
   {
@@ -106,7 +105,9 @@
     "# getting started, but may not want in the final exported results.\n",
     "DEBUG = False\n",
     "if DEBUG:\n",
-    "    captured_io()  # noqa F821"
+    "    captured_io()  # noqa F821\n",
+    "\n",
+    "from wordcloud import WordCloud, STOPWORDS  # noqa E402"
    ]
   },
   {

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+ipython<6
 pytest>=2.7
 pytest-cov
 future


### PR DESCRIPTION
the wordcloud import should come after the `pip install wordcloud`
command, or you'll end up with a library not found error